### PR TITLE
Add skin auto patching after configurable delay of seconds

### DIFF
--- a/staging/script.ozweather-skinpatcher/addon.xml
+++ b/staging/script.ozweather-skinpatcher/addon.xml
@@ -9,18 +9,17 @@
     </extension>
     <extension point="xbmc.service" library="service.py" />
     <extension point="xbmc.addon.metadata">
-        <summary lang="en_GB">Patch Kodi skins (Estuary, Estouchy, Confluence, Amber, Aeon etc.) for OzWeather Radar
-            Support.
-        </summary>
+        <summary lang="en_GB">Patch Kodi skins for OzWeather Radar Support.</summary>
         <description lang="en_GB">
-            This addon attempts to patch Kodi skins for OzWeather radar support.
-            Supports: Estuary, Estouchy, Confluence, A Confluence Zeitgeist, Xonfluence, OSMC, Amber, Aeon (Nox Silvo
-            and Tajo)
-            Skin folder **must be writeable!**
-            (Creates a backup of of the original skin files first and this addon can also restore those if need be).
-            By default, patches only the actual weather page.
-            For Estuary &amp; Confluence, this also patches your VideoFullScreen file for weather/radar during playback when
-            video info is displayed.
+Supports: Estuary, Estouchy, Confluence, A Confluence Zeitgeist, Xonfluence, OSMC, Amber, Aeon (Nox Silvo
+and Tajo)
+- This addon attempts to patch Kodi skins for OzWeather radar support.
+- By default, will auto-patch your skin every time a new version of the skin arrives.
+- Skin folder **must be writeable!**
+- Creates a backup of the original skin files first and this addon can also restore those if need be).
+- By default, patches only the actual weather page.
+- For Estuary &amp; Confluence, this also patches your VideoFullScreen file for weather during playback when
+video info is displayed.
         </description>
         <platform>all</platform>
         <license>GPL-3.0-only</license>

--- a/staging/script.ozweather-skinpatcher/addon.xml
+++ b/staging/script.ozweather-skinpatcher/addon.xml
@@ -7,6 +7,7 @@
     <extension point="xbmc.python.script" library="default.py">
         <provides>executable</provides>
     </extension>
+    <extension point="xbmc.service" library="service.py" />
     <extension point="xbmc.addon.metadata">
         <summary lang="en_GB">Patch Kodi skins (Estuary, Estouchy, Confluence, Amber, Aeon etc.) for OzWeather Radar
             Support.

--- a/staging/script.ozweather-skinpatcher/resources/language/resource.language.en_gb/strings.po
+++ b/staging/script.ozweather-skinpatcher/resources/language/resource.language.en_gb/strings.po
@@ -60,3 +60,23 @@ msgstr ""
 msgctxt "#32011"
 msgid "Show First Run Info"
 msgstr ""
+
+msgctxt "#32012"
+msgid "OzWeather Settings"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Enable auto-patching (works from next reboot)?"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Skin Specific"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Auto patch: if update required, auto patch & reload skin soon after Kodi startup"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Delays seconds before patching (to allow for addon updates)"
+msgstr ""

--- a/staging/script.ozweather-skinpatcher/resources/language/resource.language.en_gb/strings.po
+++ b/staging/script.ozweather-skinpatcher/resources/language/resource.language.en_gb/strings.po
@@ -74,11 +74,11 @@ msgid "Skin Specific"
 msgstr ""
 
 msgctxt "#32015"
-msgid "Auto patch: if update required, auto patch & reload skin soon after Kodi startup"
+msgid "Auto patch: if new skin version, auto patch & reload skin after Kodi startup"
 msgstr ""
 
 msgctxt "#32016"
-msgid "Delays seconds before patching (to allow for addon updates)"
+msgid "After how many seconds (allows for addon updates)"
 msgstr ""
 
 msgctxt "#32017"

--- a/staging/script.ozweather-skinpatcher/resources/language/resource.language.en_gb/strings.po
+++ b/staging/script.ozweather-skinpatcher/resources/language/resource.language.en_gb/strings.po
@@ -46,7 +46,7 @@ msgid "Low Temps (default skyblue)"
 msgstr ""
 
 msgctxt "#32009"
-msgid "Show background art? (only Amber/Aeon)"
+msgid "Show background art?"
 msgstr ""
 
 msgctxt "#32007"
@@ -66,7 +66,7 @@ msgid "OzWeather Settings"
 msgstr ""
 
 msgctxt "#32013"
-msgid "Enable auto-patching (works from next reboot)?"
+msgid "Enable auto-patching (from next reboot)?"
 msgstr ""
 
 msgctxt "#32014"
@@ -79,4 +79,8 @@ msgstr ""
 
 msgctxt "#32016"
 msgid "Delays seconds before patching (to allow for addon updates)"
+msgstr ""
+
+msgctxt "#32017"
+msgid "(Amber and Neon only)"
 msgstr ""

--- a/staging/script.ozweather-skinpatcher/resources/lib/ozweather_skinpatcher.py
+++ b/staging/script.ozweather-skinpatcher/resources/lib/ozweather_skinpatcher.py
@@ -32,7 +32,7 @@ def version_tuple(version_str) -> tuple:
 
 def delayed_autopatch():
 
-    Logger.start("Delayed autopatch thread")
+    Logger.start("(delayed autopatch thread)")
     # Delay for 40 seconds to allow addon updates
     delay_setting = get_setting('delay_seconds')
     try:
@@ -54,7 +54,7 @@ def delayed_autopatch():
             with open(os.path.join(PROFILE, Store.current_skin), 'r') as f:
                 skin_version_recorded = f.read()
             if skin_version_recorded == skin_version_now:
-                Logger.info(f'This skin version has already been patched - now: [{skin_version_now}] == recorded: [{skin_version_recorded}]')
+                Logger.info(f'This skin version has already been patched - now: [{skin_version_now}] == recorded: [{skin_version_recorded}] - doing nothing.')
                 this_skin_version_patched = True
             else:
                 Logger.info(f'This skin version has NOT been patched: - now: [{skin_version_now}] != recorded: [{skin_version_recorded}]')
@@ -72,7 +72,7 @@ def delayed_autopatch():
         xbmc.executebuiltin('ReloadSkin()')
         Notify.info('Successful Ozweather skin patch (skin reloaded).')
 
-    Logger.stop("Delayed autopatch thread")
+    Logger.stop("(delayed autopatch thread)")
 
 def autopatch():
     """

--- a/staging/script.ozweather-skinpatcher/resources/lib/ozweather_skinpatcher.py
+++ b/staging/script.ozweather-skinpatcher/resources/lib/ozweather_skinpatcher.py
@@ -60,7 +60,7 @@ def delayed_autopatch():
                 Logger.info(f'This skin version has NOT been patched: - now: [{skin_version_now}] != recorded: [{skin_version_recorded}]')
                 this_skin_version_already_patched = False
 
-    except (FileNotFoundError, IOError, OSError, PermissionError, ValueError) as e:
+    except (RuntimeError, FileNotFoundError, IOError, OSError, PermissionError, ValueError) as e:
         Logger.error("Unable to determine if skin is already patched - assuming it hasn't been patched")
         Logger.error(e)
 

--- a/staging/script.ozweather-skinpatcher/resources/lib/ozweather_skinpatcher.py
+++ b/staging/script.ozweather-skinpatcher/resources/lib/ozweather_skinpatcher.py
@@ -35,7 +35,11 @@ def delayed_autopatch():
 
     Logger.start("Delayed autopatch thread")
     # Delay for 40 seconds to allow addon updates
-    delay_seconds = int(get_setting('delay_seonds')) or 30
+    delay_setting = get_setting('delay_seconds')
+    try:
+        delay_seconds = int(delay_setting)
+    except (TypeError, ValueError):
+        delay_seconds = 30
     Logger.info(f"Automatically patching OzWeather after delay of {delay_seconds} seconds from now (to allow Kodo time to update addons")
     xbmc.sleep(delay_seconds * 1000)
 
@@ -55,8 +59,9 @@ def delayed_autopatch():
                 Logger.info(f'This skin version has NOT been patched: - now: [{skin_version_now}] != recorded: [{skin_version_recorded}]')
                 this_skin_version_patched = False
 
-    except:
-        Logger.warning("Unable to determine if skin is already patched - assuming it hasn't been patched")
+    except Exception as e:
+        Logger.error("Unable to determine if skin is already patched - assuming it hasn't been patched")
+        Logger.error(e)
 
     if not this_skin_version_patched:
         patch()

--- a/staging/script.ozweather-skinpatcher/resources/lib/ozweather_skinpatcher.py
+++ b/staging/script.ozweather-skinpatcher/resources/lib/ozweather_skinpatcher.py
@@ -71,12 +71,12 @@ def delayed_autopatch():
             with open(os.path.join(PROFILE, Store.current_skin), 'w', encoding='utf-8') as f:
                 f.write(skin_version_now)
         except (IOError, OSError) as e:
-            Logger.error(f"Failed to write patch record")
+            Logger.error("Failed to write patch record")
             Logger.error(e)
 
         Logger.info("Reloading skin to pick up changes")
         xbmc.executebuiltin('ReloadSkin()')
-        Notify.info('Successful Ozweather skin patch (skin reloaded).')
+        Notify.info('Successful OzWeather skin patch (skin reloaded).')
 
     Logger.stop("(delayed autopatch thread)")
 
@@ -274,7 +274,7 @@ def run():
     if mode == 0 or mode == 1:
         Logger.info("Reloading skin to pick up changes")
         xbmc.executebuiltin('ReloadSkin()')
-        Notify.info('Successful Ozweather skin patch (skin reloaded).')
+        Notify.info('Successful OzWeather skin patch (skin reloaded).')
 
     # and, we're done...
     Logger.stop()

--- a/staging/script.ozweather-skinpatcher/resources/lib/store.py
+++ b/staging/script.ozweather-skinpatcher/resources/lib/store.py
@@ -1,7 +1,8 @@
 import os
 import sys
+import xbmc
 import xbmcvfs
-from bossanova808.constants import *
+from bossanova808.constants import CWD
 from bossanova808.logger import Logger
 
 
@@ -12,9 +13,11 @@ class Store:
         pass
     
     supported_skins = ['amber', 'estuary', 'estouchy', 'confluence', 'xonfluence', 'aczg', 'aeon', 'osmc']
-    current_skin = xbmcvfs.translatePath('special://skin')
+    current_skin_path = xbmcvfs.translatePath('special://skin')
+    current_skin = os.path.basename(current_skin_path.rstrip('/').rstrip('\\'))
 
-    Logger.info(f'special://skin Is [{current_skin}]')
+    Logger.info(f'special://skin is [{current_skin_path}]')
+    Logger.info(f'current_skin is [{current_skin}]')
     Logger.info(f'CWD is {CWD}')
 
     skin = None
@@ -30,22 +33,22 @@ class Store:
     #  (skin var in the addon id must match the name of the tweaks file!)
     #  e.g. amber or aeon.nox.silvo etc.
 
-    if 'amber' in current_skin:
-        Logger.info('Amber in skin folder name...proceeding...')
+    if 'amber' in current_skin_path:
+        Logger.info('Amber in skin folder name -> skin supported.')
         skin = 'amber'
         destination_skin_xml_folder = '1080i'
-    if 'estuary' in current_skin:
-        Logger.info('Estuary in skin folder name...proceeding...')
+    if 'estuary' in current_skin_path:
+        Logger.info('Estuary in skin folder name -> skin supported.')
         skin = 'estuary'
         destination_skin_xml_folder = 'xml'
-    if 'estouchy' in current_skin:
-        Logger.info('Estouchy in skin folder name...proceeding...')
+    if 'estouchy' in current_skin_path:
+        Logger.info('Estouchy in skin folder name -> skin supported.')
         skin = 'estouchy'
         destination_skin_xml_folder = 'xml'
     # Note Confluence changed from 720 -> 1080 with Omega, so handle that here
     # and below when working out the destination folder
-    if 'confluence' in current_skin:
-        Logger.info('confluence in skin folder name...proceeding...')
+    if 'confluence' in current_skin_path:
+        Logger.info('confluence in skin folder name -> skin supported.')
         skin = 'confluence'
         # Kodi > Omega, when Confluence became 1080p...
         if int(xbmc.getInfoLabel('System.BuildVersionCode').split(".")[0]) >= 21:
@@ -55,24 +58,24 @@ class Store:
             destination_skin_xml_folder = '720p'
             skin_specific_xml_source_folder = os.path.join(CWD, 'resources', 'skin-files', skin, '720p')
     # Confluence Zeitgeist
-    if 'aczg' in current_skin:
-        Logger.info('Confluence Zeitgeist (aczg) in skin folder name...proceeding...')
+    if 'aczg' in current_skin_path:
+        Logger.info('Confluence Zeitgeist (aczg) in skin folder name -> skin supported.')
         skin = 'aczg'
         destination_skin_xml_folder = 'xml'
-    if 'xonfluence' in current_skin:
-        Logger.info('xonfluence in skin folder name...proceeding...')
+    if 'xonfluence' in current_skin_path:
+        Logger.info('xonfluence in skin folder name -> skin supported.')
         skin = 'xonfluence'
         destination_skin_xml_folder = 'xml'
-    if 'aeon.nox' in current_skin:
-        Logger.info('aeon.nox in skin folder name...proceeding...')
+    if 'aeon.nox' in current_skin_path:
+        Logger.info('aeon.nox in skin folder name -> skin supported.')
         skin = 'aeon'
         destination_skin_xml_folder = '16x9'
-    if 'aeon.tajo' in current_skin:
-        Logger.info('aeon.tajo in skin folder name...proceeding...')
+    if 'aeon.tajo' in current_skin_path:
+        Logger.info('aeon.tajo in skin folder name -> skin supported.')
         skin = 'aeon'
         destination_skin_xml_folder = '1080i'
-    if 'skin.osmc' in current_skin:
-        Logger.info('osmc in skin folder name...proceeding...')
+    if 'skin.osmc' in current_skin_path:
+        Logger.info('osmc in skin folder name -> skin supported.')
         skin = 'osmc'
         destination_skin_xml_folder = 'xml'
 
@@ -84,7 +87,7 @@ class Store:
     # (Confluence already set above due to different 720p/1080p)
     if not skin_specific_xml_source_folder:
         skin_specific_xml_source_folder = os.path.join(CWD, 'resources', 'skin-files', skin)
-    xml_destination_folder = os.path.join(current_skin, destination_skin_xml_folder)
+    xml_destination_folder = os.path.join(current_skin_path, destination_skin_xml_folder)
     current_myweather_xml = os.path.join(xml_destination_folder, 'MyWeather.xml')
     current_videofullscreen_xml = os.path.join(xml_destination_folder, 'VideoFullScreen.xml')
     backup_myweather_xml = os.path.join(xml_destination_folder, 'MyWeather.xml.original')

--- a/staging/script.ozweather-skinpatcher/resources/settings.xml
+++ b/staging/script.ozweather-skinpatcher/resources/settings.xml
@@ -16,6 +16,11 @@
                         <maximum>120</maximum>
                         <step>1</step>
                     </constraints>
+                    <dependencies>
+                        <dependency type="enable">
+                            <condition operator="is" setting="autopatch">true</condition>
+                        </dependency>
+                    </dependencies>
                     <control type="spinner" format="integer"/>
                 </setting>
             </group>

--- a/staging/script.ozweather-skinpatcher/resources/settings.xml
+++ b/staging/script.ozweather-skinpatcher/resources/settings.xml
@@ -1,13 +1,26 @@
 <?xml version="1.0" ?>
 <settings version="1">
     <section id="script.ozweather-skinpatcher">
-        <category help="" id="OzWeather Skin Patcher" label="32000">
-            <group id="1" label="32010">
-                <setting id="show_first_run_info" type="boolean" label="32011" help="">
+        <category help="" id="Basic" label="32012">
+            <group id="0" label="32015">
+                <setting id="autopatch" type="boolean" label="32013" help="">
 					<level>0</level>
 					<default>true</default>
 					<control type="toggle"/>
 				</setting>
+                <setting id="delay_seconds" type="integer" label="32002" help="">
+                    <level>0</level>
+                    <default>30</default>
+                    <constraints>
+                        <minimum>0</minimum>
+                        <maximum>120</maximum>
+                        <step>1</step>
+                    </constraints>
+                    <control type="spinner" format="integer"/>
+                </setting>
+            </group>
+            <group id="1" label="32010">
+
                 <setting id="colour_text_default" type="string" label="32008" help="">
                     <level>0</level>
                     <default>white</default>
@@ -33,6 +46,10 @@
                     <default>skyblue</default>
                     <control type="edit" format="string" />
                 </setting>
+            </group>
+        </category>
+        <category help="" id="SkinSpecific" label="32014">
+            <group id="2">
                 <setting id="background_visible_bool" type="boolean" label="32009" help="">
 					<level>0</level>
 					<default>false</default>

--- a/staging/script.ozweather-skinpatcher/resources/settings.xml
+++ b/staging/script.ozweather-skinpatcher/resources/settings.xml
@@ -8,7 +8,7 @@
 					<default>true</default>
 					<control type="toggle"/>
 				</setting>
-                <setting id="delay_seconds" type="integer" label="32002" help="">
+                <setting id="delay_seconds" type="integer" label="32016" help="">
                     <level>0</level>
                     <default>30</default>
                     <constraints>
@@ -54,7 +54,7 @@
             </group>
         </category>
         <category help="" id="SkinSpecific" label="32014">
-            <group id="2">
+            <group id="2" label="32017">
                 <setting id="background_visible_bool" type="boolean" label="32009" help="">
 					<level>0</level>
 					<default>false</default>

--- a/staging/script.ozweather-skinpatcher/service.py
+++ b/staging/script.ozweather-skinpatcher/service.py
@@ -1,0 +1,6 @@
+from bossanova808 import exception_logger
+from resources.lib import ozweather_skinpatcher
+
+if __name__ == "__main__":
+    with exception_logger.log_exception():
+        ozweather_skinpatcher.autopatch()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatic skin patching at startup runs as a background service, can be delayed, reloads the skin and shows OzWeather-specific notifications; remembers patch state to avoid reapplying.

- **Settings**
  - New options: “Enable auto-patching” and “Delay (seconds) before patching.”
  - Settings reorganised into “Basic” and “Skin Specific”; “Show First Run Info” removed.
  - New skin-specific controls: “Show background art?” and background opacity.

- **Localization**
  - Added/updated English (UK) strings for new settings and labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->